### PR TITLE
Update classifier from GPL to BSD license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name="sos",
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',
-          'License :: OSI Approved :: GNU General Public License (GPL)',
+          'License :: OSI Approved :: BSD License',
           'Natural Language :: English',
           'Operating System :: POSIX :: Linux',
           'Operating System :: MacOS :: MacOS X',


### PR DESCRIPTION
The conda skeleton for PyPI packages using the PyPI classifiers to guess the software license ([source](https://github.com/conda/conda-build/blob/ea99e2dc2fa473039dbeb73d92b3f5d5c59548fe/conda_build/skeletons/pypi.py#L828)). Thus `conda skeleton pypi sos` results in the GPL license being added to the recipe (which caused some [confusion in the bioconda submission](https://github.com/bioconda/bioconda-recipes/pull/9457#discussion_r203363430)).