### PR TITLE
Fix sos purge --age

### DIFF
--- a/src/sos/__main__.py
+++ b/src/sos/__main__.py
@@ -1738,7 +1738,7 @@ def cmd_purge(args, workflow_args):
     # from .monitor import summarizeExecution
     env.verbosity = args.verbosity
     try:
-        if not (args.tasks or args.all or args.status or args.tags):
+        if not (args.tasks or args.all or args.status or args.tags or args.age):
             raise ValueError(
                 "Please specify either IDs of tasks or one or more of options --all, --age, --status, or --tags."
             )


### PR DESCRIPTION
Add back checking for an `--age` argument to `sos purge` that was lost with [this commit](https://github.com/vatlab/sos/commit/0c012720708c183283448c4f09f79fccbe2a770f)