### PR TITLE
Replacing loose file permission with stricter permission

### DIFF
--- a/src/sos/hosts.py
+++ b/src/sos/hosts.py
@@ -77,7 +77,7 @@ class DaemonizedProcess(mp.Process):
             sys.exit(1)
 
         os.setsid()
-        os.umask(0)
+        os.umask(os.umask(0))
         # do second fork
         try:
             pid = os.fork()


### PR DESCRIPTION
# What is wrong?

In file: [hosts.py](https://github.com/vatlab/sos/blob/master/src/sos/hosts.py#L77) in class `DaemonizedProcess` method `run()` sets umask value to `0` that grants full permission to all users except the owner and the member of the groups instead of setting the value to default value of the system. When permissions settings for a resource are configured to provide access to a broader spectrum of individuals or entities than is truly essential, it opens the possibility of sensitive data being exposed or the resource being altered by unintended or unauthorized parties. This underscores the significance of implementing precise and tailored permissions to uphold data security and resource integrity. More information is available in: https://cwe.mitre.org/data/definitions/732.html

# Proposed Fix

Instead of using `os.umask(0)` which can be dangerous, use the system's default umask value

```python
- os.umask(0)
+ os.umask(os.umask(0))
```

# Issue Type

- Bug fix pull request

# Component Name

- /src/sos/hosts.py

# Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the iCR tool by [OpenRefactory, Inc.](https://openrefactory.com/) and then manually triaging the results.